### PR TITLE
Message box clears automatically after sending a message

### DIFF
--- a/app/views/channel/channel-controller.js
+++ b/app/views/channel/channel-controller.js
@@ -20,9 +20,6 @@ export default function ChannelController($q, $stateParams, state, contacts,
           channelCursor.get([this.channelId, 'channelInfo']),
           this.message
         )
-        .then(() => {
-          this.message = '';
-        })
         .catch((error) => {
           if (error !== 'timeout') {
             return $q.reject(error);
@@ -33,6 +30,9 @@ export default function ChannelController($q, $stateParams, state, contacts,
     };
 
     return recursivelySendMessage()
+      .then(() => {
+        this.message = '';
+      })
       .catch((error) => notification.error(error, 'Message Delivery Error'));
   };
 


### PR DESCRIPTION
If I only want a callback for success, is it a good practice to leave out the second argument in then()?
